### PR TITLE
DD-1457 Fix Resolving XML eXternal Entity in user-controlled data - P…

### DIFF
--- a/src/main/java/nl/knaw/dans/sword2examples/Common.java
+++ b/src/main/java/nl/knaw/dans/sword2examples/Common.java
@@ -113,7 +113,7 @@ public class Common {
 
     public static Entry parseEntry(String xmlText) {
         try {
-             var context = JAXBContext.newInstance(Entry.class);
+            var context = JAXBContext.newInstance(Entry.class);
             Unmarshaller jaxbUnmarshaller = context.createUnmarshaller();
             return (Entry) jaxbUnmarshaller.unmarshal(new StringReader(transformToSecureXmlText(xmlText)));
         }

--- a/src/main/java/nl/knaw/dans/sword2examples/Common.java
+++ b/src/main/java/nl/knaw/dans/sword2examples/Common.java
@@ -104,7 +104,7 @@ public class Common {
             Unmarshaller jaxbUnmarshaller = context.createUnmarshaller();
 
             return(Feed) jaxbUnmarshaller.unmarshal(new StringReader(transformToSecureXmlText(xmlText)));
-        }  catch (JAXBException e) {
+        } catch (JAXBException e) {
             throw new RuntimeException("Unable to parse xml text",  e);
         }
 


### PR DESCRIPTION
Fixes DD--1457 Fix Resolving XML eXternal Entity in user-controlled data 

# Description of changes
**Raw xml text after a deposit action, will be transformed to an secure xml string to avoid resolving XXE (XML External Entity) during preparing to display it or** `Unmarshalling`.

# How to test
  - Starting vagrant
    - `start-preprovisioned-box.py -s dev_archaeology`
    - To follow the deposits: `deploy.py  -m dd-manage-deposit dev_archaeology`
  
  - Deposit vaild/invalid datasets using
    - cd to local folder: `~/git/dans-core-systems/modules/dd-dans-sword2-examples` 
    - run examples: 
      - `./run-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 src/main/resources/example-bags/valid/audiences`
      - `./run-validation.sh https://dev.sword2.archaeology.datastations.nl/validate-dans-bag src/main/resources/example-bags/valid/audiences-sha256`
      - `./run-validation.sh https://dev.sword2.archaeology.datastations.nl/validate-dans-bag src/main/resources/example-bags/invalid/invalid-license`
      - `./run-continued-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 200000 src/main/resources/example-bags/valid/audiences-sha256`
    - in debugger examples:
      - `nl.knaw.dans.sword2examples.SimpleDeposit`
          `https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 src/main/resources/example-bags/valid/audiences-sha256`
      - `nl.knaw.dans.sword2examples.ContinuedDeposit`
        `https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 200000 src/main/resources/example-bags/valid/audiences-sha256`
  
  - Looking at the results:
      - in the firefox browser: `http://dev.sword2.archaeology.datastations.nl:20355/report`

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
