### PR TITLE
Fixed checksum for movements01/bag-info.txt

### DIFF
--- a/src/main/resources/example-bags/valid/movements01/tagmanifest-sha1.txt
+++ b/src/main/resources/example-bags/valid/movements01/tagmanifest-sha1.txt
@@ -1,5 +1,5 @@
 dc033ee6cf0d73d872240bdf43a3f2471c71c109 manifest-sha1.txt
 e2924b081506bac23f5fffe650ad1848a1c8ac1d bagit.txt
-cb663a72a86305936f46c15c0bd61557e1c0c994 bag-info.txt
+d55204297b600087fb81933fc5319b12822c09d1 bag-info.txt
 6b17694cb7fbc88551339301e067e08bfb5e2fb6 metadata/dataset.xml
 7f3638be2e44b22a2e04d20b5ed8ddd2603a8734 metadata/files.xml


### PR DESCRIPTION
Fixes NOISSUE

The valid example; movements01/bag-info.txt would not validate:

```
{"Bag location":null,"Name":"movements01","Profile version":"1.1.0","Information package type":"DEPOSIT","Is compliant":false,"Rule violations":[{"rule":"1.1.1","violation":"Bag is not valid: File [/var/opt/dans.knaw.nl/tmp/bag-4660425393845145010/movements01/bag-info.txt] is suppose to have a [SHA-1] hash of [cb663a72a86305936f46c15c0bd61557e1c0c994] but was computed [d55204297b600087fb81933fc5319b12822c09d1]."}]}
```

# Description of changes


# How to test
With dev_archaeology;
`./run-validation.sh https://dev.sword2.archaeology.datastations.nl/validate-dans-bag src/main/resources/example-bags/valid/movements01`

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
