### PR TITLE
DD1782: language mapping

### DIFF
--- a/src/main/resources/example-bags/valid/all-mappings/metadata/dataset.xml
+++ b/src/main/resources/example-bags/valid/all-mappings/metadata/dataset.xml
@@ -312,7 +312,7 @@
         <!-- RIG002 see profile -->
 
         <!-- RIG003 Any element can add a metadata language -->
-        <dcterms:abstract xml:lang="ka">Georgian</dcterms:abstract>
+        <dcterms:abstract xml:lang="ko">Korean</dcterms:abstract>
 
 
         <!-- REL001 see profile -->

--- a/src/main/resources/example-bags/valid/all-mappings/tagmanifest-sha1.txt
+++ b/src/main/resources/example-bags/valid/all-mappings/tagmanifest-sha1.txt
@@ -1,4 +1,4 @@
-e12d5b1922bef5688eed519d2cd981b2f564334a  metadata/dataset.xml
+1a8c59eae15dae9d7567fb4780ec2f4f25dd4066  metadata/dataset.xml
 33d507e3ced80f1b83f8e73ae780e870e159de9a  metadata/files.xml
 e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt
 fcebcebafb062a34ecee8f475cfa81cb745fbed6  manifest-sha1.txt


### PR DESCRIPTION
Fixes DD1782: language mapping

# Description of changes

# How to test

* [x] build this PR, build related PR, deploy related PR
* run changed example manually

      ./run-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 src/main/resources/example-bags/valid/all-mappings

* [x] result before deploy: 400 with `'Kalaallisut, Greenlandic' does not exist in type 'language'`,  
  ~after deploy: 400 `Haitian Creole, Haitian' does not exist in type 'dansMetadataLanguage'`~

# Related PRs

(Add links)

* fix unit test of https://github.com/DANS-KNAW/dd-dataverse-ingest/pull/25

# Notify

@DANS-KNAW/core-systems
