### PR TITLE
DD-1946: upgrade parent

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ mvn clean install
    myuser mypassword bag1 bag2 bag3
 # Deposit a sequence of bags, the first one being a new dataset, the others being updates to 
 # this dataset, each in chunks of configurable size
-./run-sequence-continued-deposit.sh SequenceContinued https://demo.sword2.domain.datastations.nl/collection/1 \
+./run-sequence-continued-deposit.sh https://demo.sword2.domain.datastations.nl/collection/1 \
    myuser mypassword chunksize bag1 bag2 bag3
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>1.9.1-SNAPSHOT</version>
+        <version>1.10.0</version>
     </parent>
     <artifactId>dd-dans-sword2-examples</artifactId>
     <name>DD DANS SWORD2 Examples</name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>1.9.0</version>
+        <version>1.9.1-SNAPSHOT</version>
     </parent>
     <artifactId>dd-dans-sword2-examples</artifactId>
     <name>DD DANS SWORD2 Examples</name>
@@ -53,7 +53,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.14</version>
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans</groupId>
@@ -78,7 +77,6 @@
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <version>2.3.3</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/src/main/java/nl/knaw/dans/sword2examples/Common.java
+++ b/src/main/java/nl/knaw/dans/sword2examples/Common.java
@@ -349,7 +349,13 @@ public class Common {
 
     public static void printXml(String xml) {
         System.out.println("-- XML: START -------");
-        System.out.println(prettyPrintByTransformer(xml, 2, false));
+        try {
+            var output = prettyPrintByTransformer(xml, 2, false);
+            System.out.println(output);
+        }
+        catch (Exception e) {
+            System.out.println(xml);
+        }
         System.out.println("-- XML: END ---------");
         System.out.println();
     }


### PR DESCRIPTION
Fixes DD-

# Description of changes

# How to test

* [x] ...

      ./run-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 src/main/resources/example-bags/valid/all-mappings

* [x] for all invalid bags and the bag above

      ./run-validation.sh https://dev.sword2.archaeology.datastations.nl/validate-dans-bag  src/main/resources/example-bags/invalid/...

* [x] ...

      ./run-sequence-simple-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1 user001 user001 src/main/resources/example-bags/valid/revision01 src/main/resources/example-bags/valid/revision02 src/main/resources/example-bags/valid/revision03
      ./run-sequence-continued-deposit.sh https://dev.sword2.archaeology.datastations.nl/collection/1  user001 user001 40000 src/main/resources/example-bags/valid/revision01 src/main/resources/example-bags/valid/revision02 src/main/resources/example-bags/valid/revision03


* [ ] an invalid password no longer causes a stack trace (because the response is not XML) but
```
Listening for transport dt_socket at address: 8000
Sending base revision of dataset ...
Using Basic-Auth: user001:user001xxx
FAILED. Status = HTTP/1.1 401 Unauthorized
Response body follows:
-- XML: START -------
[Fatal Error] :1:1: Content is not allowed in prolog.
Credentials are required to access this resource.
-- XML: END ---------

```

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
